### PR TITLE
Don't force wifi, ap, api, and ota components

### DIFF
--- a/econet_base.yaml
+++ b/econet_base.yaml
@@ -27,15 +27,6 @@ esphome:
 preferences:
   flash_write_interval: "24h"
 
-wifi:
-  ap:
-
-captive_portal:
-
-api:
-
-ota:
-
 logger:
   baud_rate: 0  # Make sure logging is not using the serial port
   level: ${logger_level}


### PR DESCRIPTION
The base configuration includes components that some people may not wish to include. There doesn't seem to be a way with esphome's package system to selectively ignore components from an included package, so it seems like letting people pull in only the components they want/need would be a better approach.